### PR TITLE
Fix mini-player z-index

### DIFF
--- a/css/Iridium.css
+++ b/css/Iridium.css
@@ -234,7 +234,7 @@ html:not(.iri-always-visible):not(.iri-always-playing) #iri-mini-player-controls
     position: fixed;
     right: 10px;
     width: 352px;
-    z-index: 10;
+    z-index: 300;
 }
 .iri-always-visible:not(.iri-full-browser) #movie_player:not(.ytp-fullscreen):before,
 .iri-always-playing #movie_player:not(.ytp-fullscreen):not(.unstarted-mode):before {


### PR DESCRIPTION
The forward/backward buttons on the YouTube main page have a z-index of 200 and thus are in front of the mini-player.