### PR TITLE
fix volume scroll in chrome 73

### DIFF
--- a/src/Userscript/Iridium.user.js
+++ b/src/Userscript/Iridium.user.js
@@ -3559,7 +3559,7 @@
                             return;
                         }
 
-                        document.addEventListener("wheel", this.changeVolume.bind(this));
+                        document.addEventListener("wheel", this.changeVolume.bind(this), {passive: false});
 
                     }
                 },

--- a/src/Webextension/js/Iridium.user.js
+++ b/src/Webextension/js/Iridium.user.js
@@ -3559,7 +3559,7 @@
                             return;
                         }
 
-                        document.addEventListener("wheel", this.changeVolume.bind(this));
+                        document.addEventListener("wheel", this.changeVolume.bind(this), {passive: false});
 
                     }
                 },


### PR DESCRIPTION
Cancelling active events with return false and preventDefault() is ignored by default in Chrome 73 in favor of faster scrolling.
https://www.chromestatus.com/feature/6662647093133312
https://developers.google.com/web/updates/2017/01/scrolling-intervention